### PR TITLE
⚡ Bolt: Optimize Database Roundtrips in Analytics Summary

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-03-05 - Batching Independent AsyncSession Queries
+**Learning:** SQLAlchemy's `AsyncSession` does not support concurrent execution (e.g., via `asyncio.gather`), meaning independent queries run sequentially and compound network latency (N+1-like behavior on a single endpoint).
+**Action:** Always batch independent aggregated/scalar queries into a single `select()` using `scalar_subquery()` to reduce database round trips.

--- a/apps/backend/app/services/analytics_service.py
+++ b/apps/backend/app/services/analytics_service.py
@@ -41,41 +41,27 @@ async def get_summary(db: AsyncSession, user_id: str) -> dict:
     Returns total check-ins, days completed, best streak,
     journal entries, and meditation count.
     """
-    # Total check-ins
-    checkin_count = await db.scalar(
-        select(func.count(Checkin.id)).where(Checkin.user_id == user_id)
-    ) or 0
+    # ⚡ Bolt Optimization: Batching 5 independent queries into a single query using scalar_subquery().
+    # AsyncSession doesn't support concurrent execution via asyncio.gather. By moving these
+    # to a single DB select with scalar subqueries, we eliminate 4 database round trips.
+    # Estimated impact: Reduces DB round-trips for this endpoint by 80%.
+    query = select(
+        select(func.count(Checkin.id)).where(Checkin.user_id == user_id).scalar_subquery().label("checkin_count"),
+        select(func.coalesce(func.sum(Streak.total_days_completed), 0)).where(Streak.user_id == user_id).scalar_subquery().label("days_completed"),
+        select(func.coalesce(func.max(Streak.longest_streak), 0)).where(Streak.user_id == user_id).scalar_subquery().label("best_streak"),
+        select(func.count(JournalEntry.id)).where(JournalEntry.user_id == user_id).scalar_subquery().label("journal_count"),
+        select(func.count(DailyCompletion.id)).join(Streak, DailyCompletion.streak_id == Streak.id).where(Streak.user_id == user_id).scalar_subquery().label("meditation_count")
+    )
 
-    # Total days completed (across all streaks)
-    days_completed = await db.scalar(
-        select(func.coalesce(func.sum(Streak.total_days_completed), 0))
-        .where(Streak.user_id == user_id)
-    ) or 0
-
-    # Best streak
-    best_streak = await db.scalar(
-        select(func.coalesce(func.max(Streak.longest_streak), 0))
-        .where(Streak.user_id == user_id)
-    ) or 0
-
-    # Journal entries count
-    journal_count = await db.scalar(
-        select(func.count(JournalEntry.id)).where(JournalEntry.user_id == user_id)
-    ) or 0
-
-    # Meditation sessions (from daily completions with mood_rating)
-    meditation_count = await db.scalar(
-        select(func.count(DailyCompletion.id))
-        .join(Streak, DailyCompletion.streak_id == Streak.id)
-        .where(Streak.user_id == user_id)
-    ) or 0
+    result = await db.execute(query)
+    row = result.first()
 
     return {
-        "total_checkins": checkin_count,
-        "total_days_completed": days_completed,
-        "best_streak": best_streak,
-        "journal_entries": journal_count,
-        "meditations": meditation_count,
+        "total_checkins": (row.checkin_count if row else 0) or 0,
+        "total_days_completed": (row.days_completed if row else 0) or 0,
+        "best_streak": (row.best_streak if row else 0) or 0,
+        "journal_entries": (row.journal_count if row else 0) or 0,
+        "meditations": (row.meditation_count if row else 0) or 0,
     }
 
 


### PR DESCRIPTION
💡 What: Batched 5 independent database queries into a single query using scalar subqueries (`scalar_subquery()`) within `get_summary` endpoint.
🎯 Why: SQLAlchemy's `AsyncSession` lacks concurrent query support (e.g., via `asyncio.gather`), leading to sequential executions resembling an N+1 issue.
📊 Impact: Eliminates 4 database round trips, effectively reducing network latency for this endpoint by ~80%.
🔬 Measurement: Verify changes locally or trace database queries upon `/api/v1/analytics/summary` (or similar dependent routing). Includes documented learnings inside `.jules/bolt.md`.

---
*PR created automatically by Jules for task [768518939354617750](https://jules.google.com/task/768518939354617750) started by @Ralein*