### PR TITLE
⚡ Bolt: [concurrent api calls in events search]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-04 - Backend concurrency for independent API calls
+**Learning:** Found sequential independent network calls in `apps/backend/app/services/events_service.py` where `_search_google_places` and `_search_eventbrite` are executed sequentially via `await ...`. This effectively doubles the latency. In an async context with independent IO-bound calls, `asyncio.gather` should be used instead.
+**Action:** When making multiple independent API requests to third parties, wrap them in `asyncio.gather` to execute concurrently, reducing latency to the duration of the slowest call instead of the sum of both.

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -5,6 +5,7 @@ with Eventbrite event listings, merges and deduplicates results.
 """
 
 import hashlib
+import asyncio
 import httpx
 import time
 from urllib.parse import quote_plus
@@ -330,10 +331,15 @@ async def search_events(
     if cached is not None:
         return cached
 
-    # Fire both API calls
+    # Fire both API calls concurrently
+    # ⚡ Bolt: Using asyncio.gather instead of sequential awaits for independent IO calls.
+    # This prevents the latency of both requests from accumulating, cutting response
+    # time to the duration of the slowest API request.
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 


### PR DESCRIPTION
💡 **What:** Switched sequential await calls to `asyncio.gather` for two independent third-party API queries in `events_service.py` (`_search_google_places` and `_search_eventbrite`).

🎯 **Why:** To improve endpoint performance. Because these two requests do not depend on each other, executing them sequentially doubles network latency for the end user.

📊 **Impact:** Cuts down the endpoint response time to match the duration of the single slowest network request instead of the sum of both.

🔬 **Measurement:** You can test the event search endpoint. The latency should be noticeably reduced, practically cut in half. I have also left an entry in `.jules/bolt.md` reflecting this specific optimization.

---
*PR created automatically by Jules for task [1757798508575889070](https://jules.google.com/task/1757798508575889070) started by @Ralein*