### PR TITLE
⚡ Bolt: Batch analytics summary queries to reduce database round-trips

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-04-05 - SQLAlchemy AsyncSession Concurrency Limitation
+**Learning:** `SQLAlchemy AsyncSession` does not support `asyncio.gather` for concurrent database queries because it is not thread-safe. Attempting to run multiple queries concurrently using the same session will result in errors.
+**Action:** Always batch independent queries into a single `select()` statement using `scalar_subquery()` to reduce database round-trips when reading multiple independent statistics or counts, instead of making multiple sequential `await db.scalar()` calls.

--- a/apps/backend/app/services/analytics_service.py
+++ b/apps/backend/app/services/analytics_service.py
@@ -41,41 +41,29 @@ async def get_summary(db: AsyncSession, user_id: str) -> dict:
     Returns total check-ins, days completed, best streak,
     journal entries, and meditation count.
     """
-    # Total check-ins
-    checkin_count = await db.scalar(
-        select(func.count(Checkin.id)).where(Checkin.user_id == user_id)
-    ) or 0
-
-    # Total days completed (across all streaks)
-    days_completed = await db.scalar(
-        select(func.coalesce(func.sum(Streak.total_days_completed), 0))
-        .where(Streak.user_id == user_id)
-    ) or 0
-
-    # Best streak
-    best_streak = await db.scalar(
-        select(func.coalesce(func.max(Streak.longest_streak), 0))
-        .where(Streak.user_id == user_id)
-    ) or 0
-
-    # Journal entries count
-    journal_count = await db.scalar(
-        select(func.count(JournalEntry.id)).where(JournalEntry.user_id == user_id)
-    ) or 0
-
-    # Meditation sessions (from daily completions with mood_rating)
-    meditation_count = await db.scalar(
+    # ⚡ Bolt Optimization: Batching independent database queries
+    # Impact: Reduces database round-trips from 5 to 1.
+    # Note: SQLAlchemy AsyncSession does not support concurrent execution (e.g. asyncio.gather).
+    #       Batching queries using single select statements with scalar subqueries is the most performant approach.
+    query = select(
+        select(func.count(Checkin.id)).where(Checkin.user_id == user_id).scalar_subquery().label("total_checkins"),
+        select(func.coalesce(func.sum(Streak.total_days_completed), 0)).where(Streak.user_id == user_id).scalar_subquery().label("days_completed"),
+        select(func.coalesce(func.max(Streak.longest_streak), 0)).where(Streak.user_id == user_id).scalar_subquery().label("best_streak"),
+        select(func.count(JournalEntry.id)).where(JournalEntry.user_id == user_id).scalar_subquery().label("journal_entries"),
         select(func.count(DailyCompletion.id))
         .join(Streak, DailyCompletion.streak_id == Streak.id)
-        .where(Streak.user_id == user_id)
-    ) or 0
+        .where(Streak.user_id == user_id).scalar_subquery().label("meditations")
+    )
+
+    result = await db.execute(query)
+    row = result.one()
 
     return {
-        "total_checkins": checkin_count,
-        "total_days_completed": days_completed,
-        "best_streak": best_streak,
-        "journal_entries": journal_count,
-        "meditations": meditation_count,
+        "total_checkins": row.total_checkins or 0,
+        "total_days_completed": row.days_completed or 0,
+        "best_streak": row.best_streak or 0,
+        "journal_entries": row.journal_entries or 0,
+        "meditations": row.meditations or 0,
     }
 
 


### PR DESCRIPTION
💡 What: The optimization implemented
Replaced 5 separate sequential database queries in `get_summary` with a single batched query using `scalar_subquery()`.

🎯 Why: The performance problem it solves
SQLAlchemy `AsyncSession` does not support `asyncio.gather` for concurrent database calls. Previously, `get_summary` would block and wait for 5 sequential database calls to complete. By batching them into a single `select` query, we eliminate 4 database round-trips.

📊 Impact: Expected performance improvement
Reduces database round-trips for the analytics summary endpoint from 5 to 1, significantly improving the endpoint latency and database connection efficiency.

🔬 Measurement: How to verify the improvement
Run the backend tests or benchmark the `/api/v1/analytics/summary` endpoint to observe the decreased response time.

---
*PR created automatically by Jules for task [17466812413212198715](https://jules.google.com/task/17466812413212198715) started by @Ralein*