### PR TITLE
⚡ Bolt: Parallelize external API calls in events_service

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-04-08 - Parallelize HTTP requests with asyncio.gather
+**Learning:** While SQLAlchemy AsyncSession does not support concurrent execution for database calls due to threading limitations, independent external HTTP requests (e.g., via httpx.AsyncClient) do not share this restriction.
+**Action:** Use `asyncio.gather` for independent external API calls to execute them concurrently, bringing overall network latency down from the sum of delays to the maximum of delays.

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -5,6 +5,7 @@ with Eventbrite event listings, merges and deduplicates results.
 """
 
 import hashlib
+import asyncio
 import httpx
 import time
 from urllib.parse import quote_plus
@@ -332,8 +333,13 @@ async def search_events(
 
     # Fire both API calls
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+
+    # Bolt: Parallelized independent HTTP requests to reduce total network latency.
+    # Overall latency is now max(google_latency, eb_latency) instead of google_latency + eb_latency.
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 


### PR DESCRIPTION
💡 **What:** Modified `search_events` in `apps/backend/app/services/events_service.py` to use `asyncio.gather` for executing Google Places and Eventbrite API queries concurrently.
🎯 **Why:** To eliminate sequential blocking, drastically reducing overall network latency by making the total request time the maximum of the two requests instead of their sum.
📊 **Impact:** Expected reduction in request processing time proportional to the latency of the fastest external service call (often reducing search latency by ~30-50%).
🔬 **Measurement:** This improvement can be measured by comparing the total response time of the `/events` endpoint before and after the change using network profiling tools.

---
*PR created automatically by Jules for task [4576964924031171875](https://jules.google.com/task/4576964924031171875) started by @Ralein*