### PR TITLE
⚡ Bolt: [performance improvement] Parallelize independent external API requests

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-10 - Parallelize independent external API requests
+**Learning:** While database queries via `AsyncSession` in SQLAlchemy are restricted from concurrent execution because they are not thread-safe, independent external HTTP requests (e.g., via `httpx.AsyncClient`) do not share this limitation.
+**Action:** When making multiple external API calls that do not depend on each other, use `asyncio.gather` to execute them concurrently instead of sequentially to reduce overall latency.

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -4,6 +4,7 @@ Real events only — no mock data. Combines Google Places Nearby Search
 with Eventbrite event listings, merges and deduplicates results.
 """
 
+import asyncio
 import hashlib
 import httpx
 import time
@@ -330,10 +331,14 @@ async def search_events(
     if cached is not None:
         return cached
 
-    # Fire both API calls
+    # Fire both API calls concurrently
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+
+    # ⚡ Bolt Optimization: Use asyncio.gather to fetch from external APIs concurrently
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto


### PR DESCRIPTION
💡 What: Refactored `search_events` in `apps/backend/app/services/events_service.py` to fetch Google Places and Eventbrite events concurrently using `asyncio.gather` instead of sequentially.
🎯 Why: To improve performance. Because these API calls are independent, running them concurrently drastically reduces the time needed to merge results.
📊 Impact: The maximum latency for searching events is now bounded by the slower of the two API calls rather than the sum of their latencies.
🔬 Measurement: Verified functionality by passing testing. Latency can be measured by tracing HTTP calls in an integrated environment. Added learning log to `.jules/bolt.md`.

---
*PR created automatically by Jules for task [15753115624474312493](https://jules.google.com/task/15753115624474312493) started by @Ralein*