### PR TITLE
⚡ Bolt: [performance improvement] Batch Expo push notifications

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-25 - Batching API calls in loops
+**Learning:** Sending external HTTP requests (like push notifications) sequentially in a loop inside Celery tasks accumulates network latency, leading to N+1 API call bottlenecks and slower background processing.
+**Action:** Always look for and utilize bulk or batch APIs (e.g., `send_bulk_push_notifications`) when processing lists of items in background tasks to reduce external HTTP requests and improve efficiency.

--- a/apps/backend/app/services/notification_scheduler.py
+++ b/apps/backend/app/services/notification_scheduler.py
@@ -17,7 +17,7 @@ from app.models.user import User
 from app.models.streak import Streak
 from app.models.push_token import PushToken
 from app.models.notification_preferences import NotificationPreferences
-from app.services.notification_service import send_push_notification
+from app.services.notification_service import send_bulk_push_notifications
 
 from celery import shared_task
 import asyncio
@@ -94,6 +94,9 @@ async def send_daily_reminders():
 
         rows = result.all()
 
+        # ⚡ Bolt Optimization: Batch push notifications to avoid N+1 network requests
+        # Reduces latency when processing many users simultaneously.
+        messages = []
         for user, push_token, prefs, streak in rows:
             # Skip if daily reminders disabled
             if prefs and not prefs.daily_reminder_enabled:
@@ -121,13 +124,16 @@ async def send_daily_reminders():
             day = (streak.current_streak + 1) if streak else 1
             body = _pick_template(DAILY_REMINDER_TEMPLATES, user.name, day)
 
-            await send_push_notification(
-                token=push_token.token,
-                title="VinR Daily Reminder",
-                body=body,
-                data={"screen": "journey", "action": "mark_complete"},
-                channel_id="streaks",
-            )
+            messages.append({
+                "token": push_token.token,
+                "title": "VinR Daily Reminder",
+                "body": body,
+                "data": {"screen": "journey", "action": "mark_complete"},
+                "channel_id": "streaks",
+            })
+
+        if messages:
+            await send_bulk_push_notifications(messages)
 
 
 async def send_streak_at_risk_notifications():
@@ -152,6 +158,8 @@ async def send_streak_at_risk_notifications():
 
         rows = result.all()
 
+        # ⚡ Bolt Optimization: Batch push notifications to avoid N+1 network requests
+        messages = []
         for user, push_token, prefs, streak in rows:
             if prefs and not prefs.streak_at_risk_enabled:
                 continue
@@ -165,13 +173,16 @@ async def send_streak_at_risk_notifications():
             day = streak.current_streak + 1
             body = _pick_template(STREAK_AT_RISK_TEMPLATES, user.name, day)
 
-            await send_push_notification(
-                token=push_token.token,
-                title="⚠️ Streak at Risk!",
-                body=body,
-                data={"screen": "journey", "action": "mark_complete"},
-                channel_id="streaks",
-            )
+            messages.append({
+                "token": push_token.token,
+                "title": "⚠️ Streak at Risk!",
+                "body": body,
+                "data": {"screen": "journey", "action": "mark_complete"},
+                "channel_id": "streaks",
+            })
+
+        if messages:
+            await send_bulk_push_notifications(messages)
 
 
 async def send_milestone_notifications():
@@ -196,6 +207,8 @@ async def send_milestone_notifications():
 
         rows = result.all()
 
+        # ⚡ Bolt Optimization: Batch push notifications to avoid N+1 network requests
+        messages = []
         for user, push_token, prefs, streak in rows:
             if prefs and not prefs.milestone_enabled:
                 continue
@@ -209,25 +222,28 @@ async def send_milestone_notifications():
             if next_day in MILESTONES:
                 template = MILESTONE_UPCOMING_TEMPLATES[next_day]
                 body = _pick_template(template, user.name, next_day)
-                await send_push_notification(
-                    token=push_token.token,
-                    title="🎯 Milestone Ahead!",
-                    body=body,
-                    data={"screen": "journey"},
-                    channel_id="milestones",
-                )
+                messages.append({
+                    "token": push_token.token,
+                    "title": "🎯 Milestone Ahead!",
+                    "body": body,
+                    "data": {"screen": "journey"},
+                    "channel_id": "milestones",
+                })
 
             # Post-milestone (they just hit a milestone today)
             if current_day in MILESTONES and streak.last_completed_date == date.today():
                 template = POST_MILESTONE_TEMPLATES[current_day]
                 body = _pick_template(template, user.name, current_day)
-                await send_push_notification(
-                    token=push_token.token,
-                    title="🏆 Milestone Reached!",
-                    body=body,
-                    data={"screen": "journey", "action": "celebration"},
-                    channel_id="milestones",
-                )
+                messages.append({
+                    "token": push_token.token,
+                    "title": "🏆 Milestone Reached!",
+                    "body": body,
+                    "data": {"screen": "journey", "action": "celebration"},
+                    "channel_id": "milestones",
+                })
+
+        if messages:
+            await send_bulk_push_notifications(messages)
 
 
 async def send_re_engagement_notifications():
@@ -252,6 +268,8 @@ async def send_re_engagement_notifications():
 
         rows = result.all()
 
+        # ⚡ Bolt Optimization: Batch push notifications to avoid N+1 network requests
+        messages = []
         for user, push_token, prefs, streak in rows:
             if prefs and not prefs.re_engagement_enabled:
                 continue
@@ -269,13 +287,16 @@ async def send_re_engagement_notifications():
 
             body = _pick_template(RE_ENGAGEMENT_TEMPLATES, user.name)
 
-            await send_push_notification(
-                token=push_token.token,
-                title="We miss you 💙",
-                body=body,
-                data={"screen": "checkin"},
-                channel_id="streaks",
-            )
+            messages.append({
+                "token": push_token.token,
+                "title": "We miss you 💙",
+                "body": body,
+                "data": {"screen": "checkin"},
+                "channel_id": "streaks",
+            })
+
+        if messages:
+            await send_bulk_push_notifications(messages)
 
 # --- Celery Tasks ---
 


### PR DESCRIPTION
💡 What
Refactored `notification_scheduler.py` to accumulate push messages in lists and use `send_bulk_push_notifications` instead of sequentially awaiting `send_push_notification` for each user.

🎯 Why
When looping over many users in background celery tasks, awaiting an external HTTP request for each iteration caused significant network latency accumulation (N+1 HTTP request problem). Batching the requests via the Expo Push API allows for a single HTTP call to handle multiple notifications concurrently.

📊 Impact
Reduces external HTTP requests during notification jobs from N (where N is the number of users receiving a notification) to 1. This significantly reduces overall task execution time and improves Celery queue throughput.

🔬 Measurement
Review Celery task execution times for `send_daily_reminders_task`, `send_streak_at_risk_notifications_task`, `send_milestone_notifications_task`, and `send_re_engagement_notifications_task` before and after the change; there will be a noticeable reduction in average duration when processing many users.

---
*PR created automatically by Jules for task [1838187196425169866](https://jules.google.com/task/1838187196425169866) started by @Ralein*