### PR TITLE
⚡ Bolt: [performance improvement] Batch background push notifications

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-04-12 - [Background tasks sequential external HTTP calls bottleneck]
+**Learning:** Background loop processing that calls external APIs per user creates an N+1 HTTP request bottleneck, delaying task completion and unnecessarily holding database connections or resources.
+**Action:** When sending notifications to a list of users, always collect the payload in memory and use a batching API such as `send_bulk_push_notifications` instead of waiting sequentially per-message.

--- a/apps/backend/app/services/notification_scheduler.py
+++ b/apps/backend/app/services/notification_scheduler.py
@@ -17,7 +17,7 @@ from app.models.user import User
 from app.models.streak import Streak
 from app.models.push_token import PushToken
 from app.models.notification_preferences import NotificationPreferences
-from app.services.notification_service import send_push_notification
+from app.services.notification_service import send_bulk_push_notifications
 
 from celery import shared_task
 import asyncio
@@ -94,6 +94,8 @@ async def send_daily_reminders():
 
         rows = result.all()
 
+        # Bolt optimization: Batch notifications to avoid N+1 external HTTP API calls
+        messages = []
         for user, push_token, prefs, streak in rows:
             # Skip if daily reminders disabled
             if prefs and not prefs.daily_reminder_enabled:
@@ -121,13 +123,16 @@ async def send_daily_reminders():
             day = (streak.current_streak + 1) if streak else 1
             body = _pick_template(DAILY_REMINDER_TEMPLATES, user.name, day)
 
-            await send_push_notification(
-                token=push_token.token,
-                title="VinR Daily Reminder",
-                body=body,
-                data={"screen": "journey", "action": "mark_complete"},
-                channel_id="streaks",
-            )
+            messages.append({
+                "token": push_token.token,
+                "title": "VinR Daily Reminder",
+                "body": body,
+                "data": {"screen": "journey", "action": "mark_complete"},
+                "channel_id": "streaks",
+            })
+
+        if messages:
+            await send_bulk_push_notifications(messages)
 
 
 async def send_streak_at_risk_notifications():
@@ -152,6 +157,8 @@ async def send_streak_at_risk_notifications():
 
         rows = result.all()
 
+        # Bolt optimization: Batch notifications to avoid N+1 external HTTP API calls
+        messages = []
         for user, push_token, prefs, streak in rows:
             if prefs and not prefs.streak_at_risk_enabled:
                 continue
@@ -165,13 +172,16 @@ async def send_streak_at_risk_notifications():
             day = streak.current_streak + 1
             body = _pick_template(STREAK_AT_RISK_TEMPLATES, user.name, day)
 
-            await send_push_notification(
-                token=push_token.token,
-                title="⚠️ Streak at Risk!",
-                body=body,
-                data={"screen": "journey", "action": "mark_complete"},
-                channel_id="streaks",
-            )
+            messages.append({
+                "token": push_token.token,
+                "title": "⚠️ Streak at Risk!",
+                "body": body,
+                "data": {"screen": "journey", "action": "mark_complete"},
+                "channel_id": "streaks",
+            })
+
+        if messages:
+            await send_bulk_push_notifications(messages)
 
 
 async def send_milestone_notifications():
@@ -196,6 +206,8 @@ async def send_milestone_notifications():
 
         rows = result.all()
 
+        # Bolt optimization: Batch notifications to avoid N+1 external HTTP API calls
+        messages = []
         for user, push_token, prefs, streak in rows:
             if prefs and not prefs.milestone_enabled:
                 continue
@@ -209,25 +221,28 @@ async def send_milestone_notifications():
             if next_day in MILESTONES:
                 template = MILESTONE_UPCOMING_TEMPLATES[next_day]
                 body = _pick_template(template, user.name, next_day)
-                await send_push_notification(
-                    token=push_token.token,
-                    title="🎯 Milestone Ahead!",
-                    body=body,
-                    data={"screen": "journey"},
-                    channel_id="milestones",
-                )
+                messages.append({
+                    "token": push_token.token,
+                    "title": "🎯 Milestone Ahead!",
+                    "body": body,
+                    "data": {"screen": "journey"},
+                    "channel_id": "milestones",
+                })
 
             # Post-milestone (they just hit a milestone today)
             if current_day in MILESTONES and streak.last_completed_date == date.today():
                 template = POST_MILESTONE_TEMPLATES[current_day]
                 body = _pick_template(template, user.name, current_day)
-                await send_push_notification(
-                    token=push_token.token,
-                    title="🏆 Milestone Reached!",
-                    body=body,
-                    data={"screen": "journey", "action": "celebration"},
-                    channel_id="milestones",
-                )
+                messages.append({
+                    "token": push_token.token,
+                    "title": "🏆 Milestone Reached!",
+                    "body": body,
+                    "data": {"screen": "journey", "action": "celebration"},
+                    "channel_id": "milestones",
+                })
+
+        if messages:
+            await send_bulk_push_notifications(messages)
 
 
 async def send_re_engagement_notifications():
@@ -252,6 +267,8 @@ async def send_re_engagement_notifications():
 
         rows = result.all()
 
+        # Bolt optimization: Batch notifications to avoid N+1 external HTTP API calls
+        messages = []
         for user, push_token, prefs, streak in rows:
             if prefs and not prefs.re_engagement_enabled:
                 continue
@@ -269,13 +286,16 @@ async def send_re_engagement_notifications():
 
             body = _pick_template(RE_ENGAGEMENT_TEMPLATES, user.name)
 
-            await send_push_notification(
-                token=push_token.token,
-                title="We miss you 💙",
-                body=body,
-                data={"screen": "checkin"},
-                channel_id="streaks",
-            )
+            messages.append({
+                "token": push_token.token,
+                "title": "We miss you 💙",
+                "body": body,
+                "data": {"screen": "checkin"},
+                "channel_id": "streaks",
+            })
+
+        if messages:
+            await send_bulk_push_notifications(messages)
 
 # --- Celery Tasks ---
 


### PR DESCRIPTION
💡 **What**: Refactored the Celery background tasks in `apps/backend/app/services/notification_scheduler.py` to batch Expo push notifications by gathering them into a single list and using `send_bulk_push_notifications`.
🎯 **Why**: The previous implementation looped over database rows and sequentially `await`ed a network request per user. This created a classic N+1 bottleneck, delaying task completion and unnecessarily holding resources such as database connections for large datasets.
📊 **Impact**: Reduces external HTTP calls from $O(n)$ to $O(1)$ per batch/job. Network latency is no longer compounded. Execution time of the background tasks drops significantly.
🔬 **Measurement**: Measure the total runtime of the Celery job `send_daily_reminders_task` with a mock dataset of 1,000+ users before and after the patch.

---
*PR created automatically by Jules for task [10081396560085536994](https://jules.google.com/task/10081396560085536994) started by @Ralein*