### PR TITLE
⚡ Bolt: parallelize event API discovery with asyncio.gather

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-04-15 - [Backend API Parallelization]
+**Learning:** While SQLAlchemy AsyncSession restricts concurrent execution for database calls (requiring scalar subqueries), independent external HTTP requests (e.g., via `httpx.AsyncClient`) do not share this limitation. The application was sequentially awaiting API calls to Google Places and Eventbrite in `events_service.py`, resulting in latency accumulation.
+**Action:** Always use `asyncio.gather` for independent external HTTP requests to fetch data concurrently. Keep in mind that this pattern should be restricted to non-database network operations unless multiple AsyncSessions are specifically configured.

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -4,6 +4,7 @@ Real events only — no mock data. Combines Google Places Nearby Search
 with Eventbrite event listings, merges and deduplicates results.
 """
 
+import asyncio
 import hashlib
 import httpx
 import time
@@ -330,10 +331,14 @@ async def search_events(
     if cached is not None:
         return cached
 
-    # Fire both API calls
+    # Fire both API calls concurrently to reduce overall latency
+    # ⚡ Bolt: Independent external HTTP calls can be safely gathered, unlike DB sessions
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 


### PR DESCRIPTION
💡 **What:** 
Updated `search_events` in `events_service.py` to use `asyncio.gather` for making the external HTTP calls to Google Places and Eventbrite simultaneously rather than sequentially.

🎯 **Why:** 
The app previously awaited these two independent external APIs back-to-back, which artificially bottlenecked response times (latency accumulation). Because standard external HTTP requests don't suffer from the same concurrent-execution limits as `SQLAlchemy` `AsyncSession` database calls, they are safe to parallelize.

📊 **Impact:** 
Overall event discovery latency should be reduced from `Time(Google) + Time(Eventbrite)` down to roughly `Max(Time(Google), Time(Eventbrite))`, which yields significant network I/O speed improvements for event search endpoints.

🔬 **Measurement:** 
Verify performance impact by measuring execution times of API hits hitting `search_events()` in local or staging testing. Check application logs for total duration savings.

---
*PR created automatically by Jules for task [9001506787706174991](https://jules.google.com/task/9001506787706174991) started by @Ralein*