### PR TITLE
⚡ Bolt: [performance improvement] Parallelize event searches

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-03-24 - Parallelize independent external HTTP requests
+**Learning:** Sequential execution of independent external API calls (e.g., fetching from Google Places and Eventbrite one after the other) causes unnecessary performance bottlenecks. Since the underlying operations are I/O bound and handled via non-blocking HTTP clients (like `httpx.AsyncClient`), they don't share the same concurrency limitations as SQLAlchemy database calls.
+**Action:** Use `asyncio.gather` to execute independent external API calls concurrently in backend services, significantly reducing overall response time.

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -4,6 +4,7 @@ Real events only — no mock data. Combines Google Places Nearby Search
 with Eventbrite event listings, merges and deduplicates results.
 """
 
+import asyncio
 import hashlib
 import httpx
 import time
@@ -330,10 +331,12 @@ async def search_events(
     if cached is not None:
         return cached
 
-    # Fire both API calls
+    # Fire both API calls concurrently
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 


### PR DESCRIPTION
💡 What: Refactored the `search_events` function in `events_service.py` to use `asyncio.gather` for fetching data from Google Places and Eventbrite concurrently.
🎯 Why: Previously, these independent I/O bound external API calls were executing sequentially. Since they use non-blocking HTTP clients (`httpx.AsyncClient`), waiting for them one after another creates an unnecessary performance bottleneck. 
📊 Impact: Expected to significantly reduce the overall response time of the endpoint. The total latency drops from `time(Google) + time(Eventbrite)` to roughly `max(time(Google), time(Eventbrite))`.
🔬 Measurement: The optimization impact can be measured by monitoring the average latency of the `/events` endpoint before and after this change.

---
*PR created automatically by Jules for task [15729554960265914512](https://jules.google.com/task/15729554960265914512) started by @Ralein*