### PR TITLE
⚡ Bolt: [performance improvement] Parallelize event search API calls

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2026-04-17 - Parallelize External API Calls
+**Learning:** Independent external HTTP requests in async Python can be parallelized with `asyncio.gather` to reduce overall latency, avoiding sequential blocking.
+**Action:** Always check if multiple `await` calls in a row are independent and parallelize them.

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -4,6 +4,7 @@ Real events only — no mock data. Combines Google Places Nearby Search
 with Eventbrite event listings, merges and deduplicates results.
 """
 
+import asyncio
 import hashlib
 import httpx
 import time
@@ -332,8 +333,10 @@ async def search_events(
 
     # Fire both API calls
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 


### PR DESCRIPTION
💡 What: Refactored `search_events` to execute `_search_google_places` and `_search_eventbrite` simultaneously using `asyncio.gather` instead of sequentially.
🎯 Why: Both of these external API calls are completely independent. Awaiting them sequentially creates an artificial bottleneck where the total latency is the sum of both network round trips. 
📊 Impact: Total event search latency is reduced from `time(Google) + time(Eventbrite)` to `max(time(Google), time(Eventbrite))`, making the events tab load significantly faster for the end user.
🔬 Measurement: Verify by executing an event search in the frontend or logging the total execution time of `search_events` before and after this change.

---
*PR created automatically by Jules for task [6035620637097321434](https://jules.google.com/task/6035620637097321434) started by @Ralein*