### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-18 - Batching Independent Network Requests
+**Learning:** While SQLAlchemy `AsyncSession` restricts concurrent database operations, independent external HTTP requests (e.g., calling Eventbrite and Google Places APIs) do not share this limitation.
+**Action:** Use `asyncio.gather` to parallelize multiple independent I/O-bound requests instead of awaiting them sequentially to significantly reduce the overall response latency.

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -4,6 +4,7 @@ Real events only — no mock data. Combines Google Places Nearby Search
 with Eventbrite event listings, merges and deduplicates results.
 """
 
+import asyncio
 import hashlib
 import httpx
 import time
@@ -330,10 +331,12 @@ async def search_events(
     if cached is not None:
         return cached
 
-    # Fire both API calls
+    # Fire both API calls concurrently
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 


### PR DESCRIPTION
💡 What: Replaced sequential awaits of `_search_google_places` and `_search_eventbrite` with `asyncio.gather`.
🎯 Why: To reduce the total latency of the `search_events` function by executing I/O bound network requests concurrently.
📊 Impact: Reduces the overall response time of `search_events` from `T(Google) + T(Eventbrite)` to `max(T(Google), T(Eventbrite))`. This could save hundreds of milliseconds on every search query.
🔬 Measurement: Verify by measuring the execution time of `search_events` before and after this change, especially under network latency conditions.

---
*PR created automatically by Jules for task [13289203832200259189](https://jules.google.com/task/13289203832200259189) started by @Ralein*