### PR TITLE
⚡ Bolt: [performance improvement] Parallelize independent API calls using asyncio.gather

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Parallelize independent API calls using asyncio.gather
+**Learning:** Independent external HTTP requests in Python/FastAPI (like calling Eventbrite and Google Places) can and should be parallelized using `asyncio.gather` rather than sequentially awaited, which reduces total latency of the combined result. While database operations using SQLAlchemy AsyncSession restrict concurrent execution, standard httpx operations do not share this limitation.
+**Action:** When a service needs to pull data from multiple independent APIs, use `asyncio.gather` to perform these operations concurrently.

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -4,6 +4,7 @@ Real events only — no mock data. Combines Google Places Nearby Search
 with Eventbrite event listings, merges and deduplicates results.
 """
 
+import asyncio
 import hashlib
 import httpx
 import time
@@ -330,10 +331,12 @@ async def search_events(
     if cached is not None:
         return cached
 
-    # Fire both API calls
+    # Fire both API calls concurrently using asyncio.gather to reduce latency
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 


### PR DESCRIPTION
💡 What: Updated `search_events` in `apps/backend/app/services/events_service.py` to use `asyncio.gather` for fetching data from `_search_google_places` and `_search_eventbrite`.

🎯 Why: Previously, these two independent external HTTP requests were being awaited sequentially. This caused the total latency to be the sum of both requests. By parallelizing them, the total waiting time is reduced to whichever request takes the longest.

📊 Impact: Reduces total latency of the `search_events` endpoint substantially, particularly noticeable when both APIs take roughly the same amount of time to respond, cutting wait time by up to ~50%.

🔬 Measurement: Can be verified by observing the total response time for the `search_events` function when there's a cache miss. A side-by-side trace of sequential vs concurrent requests will show the two HTTP tasks running at the same time.

---
*PR created automatically by Jules for task [845647737002882256](https://jules.google.com/task/845647737002882256) started by @Ralein*