### PR TITLE
⚡ Bolt: Concurrent external API calls in events_service

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-21 - Parallelize Independent External HTTP Requests
+**Learning:** Sequential HTTP requests unnecessarily accumulate latency. Independent external API calls (unlike SQLAlchemy database queries which have session restrictions) can safely be parallelized using `asyncio.gather`.
+**Action:** When making multiple non-dependent API calls (e.g., to different providers like Google Places and Eventbrite), use `asyncio.gather` instead of awaiting them sequentially to reduce total wait time from the sum to the maximum of the individual request latencies.

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -4,6 +4,7 @@ Real events only — no mock data. Combines Google Places Nearby Search
 with Eventbrite event listings, merges and deduplicates results.
 """
 
+import asyncio
 import hashlib
 import httpx
 import time
@@ -330,10 +331,14 @@ async def search_events(
     if cached is not None:
         return cached
 
-    # Fire both API calls
+    # Fire both API calls concurrently
+    # ⚡ Bolt Optimization: Use asyncio.gather to run independent external HTTP requests concurrently.
+    # This reduces overall latency from sum(Google, Eventbrite) to max(Google, Eventbrite).
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 


### PR DESCRIPTION
💡 What: Used `asyncio.gather` in `search_events` to execute the Google Places and Eventbrite API calls concurrently instead of sequentially.
🎯 Why: In `apps/backend/app/services/events_service.py`, `_search_google_places` and `_search_eventbrite` are independent requests but were previously awaited sequentially. This caused total latency to be the sum of both external network responses.
📊 Impact: Reduces overall latency of the `search_events` function from `sum(Google_latency, Eventbrite_latency)` to `max(Google_latency, Eventbrite_latency)`.
🔬 Measurement: Verify by measuring the response time of the `/events/search` endpoint. Response times should be noticeably faster because the event APIs are fetched simultaneously.

---
*PR created automatically by Jules for task [8566834205302677429](https://jules.google.com/task/8566834205302677429) started by @Ralein*