### PR TITLE
⚡ Bolt: parallelize external HTTP calls in event service

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-22 - Parallelizing External API Calls Safely
+**Learning:** While SQLAlchemy AsyncSession restricts concurrent execution for database calls (meaning we can't use `asyncio.gather` for db queries), independent external HTTP requests (e.g., via httpx.AsyncClient) do not share this limitation. The `events_service.py` was sequentially waiting for Google Places and Eventbrite API results, causing N+1 latency accumulation on the backend.
+**Action:** Use `asyncio.gather` to parallelize independent external HTTP calls to drastically reduce endpoint latency, while remembering NOT to apply this pattern to SQLAlchemy database queries.

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -4,6 +4,7 @@ Real events only — no mock data. Combines Google Places Nearby Search
 with Eventbrite event listings, merges and deduplicates results.
 """
 
+import asyncio
 import hashlib
 import httpx
 import time
@@ -330,10 +331,12 @@ async def search_events(
     if cached is not None:
         return cached
 
-    # Fire both API calls
+    # Fire both API calls concurrently
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 


### PR DESCRIPTION
💡 **What:** Replaced sequential `await` calls to Google Places and Eventbrite APIs with `asyncio.gather` in `events_service.py`. Added `.jules/bolt.md` to journal the learning about parallelizing independent HTTP requests versus SQLAlchemy queries.

🎯 **Why:** Previously, the `search_events` function was waiting for Google Places to return before even starting the Eventbrite request, causing N+1 latency accumulation on the backend and slowing down endpoint response times.

📊 **Impact:** Reduces latency of the `search_events` endpoint from `O(Time_Google + Time_Eventbrite)` to `O(max(Time_Google, Time_Eventbrite))`, practically halving response time for this dual-source data retrieval.

🔬 **Measurement:** Verify by measuring execution time of `search_events` under network throttling. The elapsed time will now be bound by the slowest single API rather than the sum of both. Basic syntax integrity verified via `py_compile`.

---
*PR created automatically by Jules for task [9813992360673266835](https://jules.google.com/task/9813992360673266835) started by @Ralein*