### PR TITLE
⚡ Bolt: [performance improvement] Concurrent API calls for search_events

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-23 - Concurrent External API Calls in FastAPI
+**Learning:** External API requests in Python using `httpx.AsyncClient` do not block the thread and don't have the concurrency restrictions of SQLAlchemy AsyncSession. When a single route (like `search_events`) needs data from multiple independent providers (e.g., Google Places and Eventbrite), making these requests sequentially doubles the overall network latency.
+**Action:** Always use `asyncio.gather()` to fetch data from independent HTTP APIs in parallel rather than sequentially, to make the total request time bounded by the slowest individual request rather than the sum of all requests.

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -4,6 +4,7 @@ Real events only — no mock data. Combines Google Places Nearby Search
 with Eventbrite event listings, merges and deduplicates results.
 """
 
+import asyncio
 import hashlib
 import httpx
 import time
@@ -330,10 +331,13 @@ async def search_events(
     if cached is not None:
         return cached
 
-    # Fire both API calls
+    # ⚡ Bolt: Execute both independent external API calls concurrently to reduce overall latency
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 


### PR DESCRIPTION
💡 **What**: Refactored the `search_events` function to execute `_search_google_places` and `_search_eventbrite` API calls concurrently using `asyncio.gather()`. Created a journal entry in `.jules/bolt.md` documenting this optimization pattern.

🎯 **Why**: Previously, the two independent external network requests were executing sequentially. This meant the total latency was the sum of both request times (e.g., if Google Places took 500ms and Eventbrite took 600ms, the total wait was 1.1s). Because these are independent `httpx` asynchronous network requests, they can and should run in parallel without thread-blocking or SQLAlchemy concurrency constraints.

📊 **Impact**: Expected to reduce latency of the `search_events` endpoint by roughly 40-50% since the total request time will now be bounded by the single slowest API call rather than their combined sequential durations.

🔬 **Measurement**: Measure the response time of the `search_events` endpoint before and after the change using an API testing tool (like Postman or curl). The overall response time should noticeably decrease. Additionally, the new `.jules/bolt.md` entry can be reviewed to verify the learning was documented correctly.

---
*PR created automatically by Jules for task [13080049609560033729](https://jules.google.com/task/13080049609560033729) started by @Ralein*