### PR TITLE
⚡ Bolt: [performance improvement] Parallelize event search API calls

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-24 - Parallelize independent external HTTP calls
+**Learning:** In the backend, external HTTP requests (e.g., via httpx.AsyncClient) do not share the SQLAlchemy AsyncSession concurrency limitations and can be safely parallelized. Sequential awaits for independent API calls unnecessarily increase latency.
+**Action:** Always use `asyncio.gather` for multiple independent external API calls (e.g., fetching from different providers) to reduce overall response time to the maximum of the individual latencies rather than their sum.

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -4,6 +4,7 @@ Real events only — no mock data. Combines Google Places Nearby Search
 with Eventbrite event listings, merges and deduplicates results.
 """
 
+import asyncio
 import hashlib
 import httpx
 import time
@@ -330,10 +331,12 @@ async def search_events(
     if cached is not None:
         return cached
 
-    # Fire both API calls
+    # Fire both API calls concurrently to reduce latency
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 


### PR DESCRIPTION
💡 What:
Modified `search_events` in `apps/backend/app/services/events_service.py` to use `asyncio.gather` for making external API requests to Google Places and Eventbrite concurrently instead of sequentially. Also added a journal entry in `.jules/bolt.md` documenting this optimization pattern.

🎯 Why:
Sequential awaits for independent external API calls bottlenecked the `/events` endpoint, causing the total latency to be the sum of both API calls.

📊 Impact:
Reduces the response time of the external calls roughly to the maximum of the individual latencies rather than their sum, effectively cutting the API wait time by up to ~50% in optimal conditions.

🔬 Measurement:
A specific async integration test (`test_events.py` test suite) was written locally to ensure that mocking both API calls to take 0.5s each resolves the function under 0.8s overall (verifying concurrency).

---
*PR created automatically by Jules for task [9549777522952370948](https://jules.google.com/task/9549777522952370948) started by @Ralein*