### PR TITLE
⚡ Bolt: [performance improvement] Parallelize Event API Calls

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-26 - Asyncio.gather for Parallel External API Calls
+**Learning:** Sequential HTTP requests to independent third-party services (e.g., Google Places and Eventbrite) create a significant latency bottleneck. While SQLAlchemy async database calls in this project can't be gathered due to session thread-safety constraints, external HTTP calls have no such limits.
+**Action:** Always look for sequential `await`s on external HTTP calls or independent I/O tasks. Wrap them in `asyncio.gather` to reduce total execution time from sum(t1, t2) to max(t1, t2).

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -4,6 +4,7 @@ Real events only — no mock data. Combines Google Places Nearby Search
 with Eventbrite event listings, merges and deduplicates results.
 """
 
+import asyncio
 import hashlib
 import httpx
 import time
@@ -332,8 +333,13 @@ async def search_events(
 
     # Fire both API calls
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+
+    # ⚡ Bolt Optimization: Use asyncio.gather to run independent HTTP requests concurrently
+    # This removes the N+1 API call bottleneck, reducing total latency from (Google API time + Eventbrite API time) to MAX(Google API time, Eventbrite API time)
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 


### PR DESCRIPTION
💡 **What:**
Replaced sequential `await` calls with `asyncio.gather` when querying Eventbrite and Google Places APIs in `events_service.py`.

🎯 **Why:**
The previous implementation fetched Google Places results, waited for them to complete, and then initiated the Eventbrite request. Because these two external API calls are completely independent and do not rely on each other's outputs, running them sequentially creates an unnecessary N+1 style bottleneck, adding their latencies together.

📊 **Impact:**
Reduces the overall function latency from `(Google latency + Eventbrite latency)` to `MAX(Google latency, Eventbrite latency)`. In a worst-case scenario where each API takes 1 second, the total search time drops from 2 seconds to roughly 1 second, improving response times by up to 50% for this endpoint.

🔬 **Measurement:**
Tested syntax using `py_compile`. Test performance impact using an HTTP load testing tool (e.g. `wrk` or `locust`) against the `/events` endpoint, or trace the execution time of `search_events` before and after.

---
*PR created automatically by Jules for task [16043210140991740241](https://jules.google.com/task/16043210140991740241) started by @Ralein*