### PR TITLE
⚡ Bolt: Parallelize external API requests in events service

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-27 - [Concurrent External API Calls]
+**Learning:** While internal database queries with SQLAlchemy `AsyncSession` cannot be executed concurrently in `asyncio.gather` due to session state sharing restrictions, this limitation does NOT apply to independent external HTTP requests (e.g., fetching from Google Places and Eventbrite via `httpx.AsyncClient`).
+**Action:** When working with multiple independent external APIs within the same service method, always parallelize them using `asyncio.gather` instead of running them sequentially. This converts additive latency `O(N+M)` to bounded maximum latency `O(max(N, M))`.

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -4,6 +4,7 @@ Real events only — no mock data. Combines Google Places Nearby Search
 with Eventbrite event listings, merges and deduplicates results.
 """
 
+import asyncio
 import hashlib
 import httpx
 import time
@@ -330,10 +331,14 @@ async def search_events(
     if cached is not None:
         return cached
 
-    # Fire both API calls
+    # ⚡ Bolt Optimization: Fire both API calls concurrently using asyncio.gather
+    # Why: Previously, these independent HTTP requests ran sequentially, blocking each other.
+    # Impact: Reduces total request latency from O(T_google + T_eb) to O(max(T_google, T_eb)).
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 


### PR DESCRIPTION
💡 What: The `search_events` function was modified to use `asyncio.gather` to execute `_search_google_places` and `_search_eventbrite` simultaneously instead of sequentially.
🎯 Why: Previously, these independent HTTP requests ran sequentially, blocking each other and adding to overall latency.
📊 Impact: Reduces total request latency from `O(T_google + T_eb)` to `O(max(T_google, T_eb))`.
🔬 Measurement: Verify the improvement by timing requests to the events service and observing lower overall response times compared to previous sequential requests.

---
*PR created automatically by Jules for task [17784073806359135318](https://jules.google.com/task/17784073806359135318) started by @Ralein*