### PR TITLE
⚡ Bolt: Concurrent API requests in events service

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2024-04-28 - Independent External HTTP Requests Can Be Parallelized
+**Learning:** While SQLAlchemy `AsyncSession` cannot safely execute concurrent database queries due to lack of thread-safety, independent external HTTP requests (e.g., via `httpx.AsyncClient`) do not share this limitation.
+**Action:** Always look for opportunities to parallelize independent external API calls using `asyncio.gather` to significantly reduce overall latency, as demonstrated in `events_service.py` where Google Places and Eventbrite searches were combined.

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -4,6 +4,7 @@ Real events only — no mock data. Combines Google Places Nearby Search
 with Eventbrite event listings, merges and deduplicates results.
 """
 
+import asyncio
 import hashlib
 import httpx
 import time
@@ -330,10 +331,12 @@ async def search_events(
     if cached is not None:
         return cached
 
-    # Fire both API calls
+    # Fire both API calls concurrently to reduce latency
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 


### PR DESCRIPTION
💡 What: Replaced sequential `await`s with `asyncio.gather()` for `_search_google_places` and `_search_eventbrite` in the `search_events` function.
🎯 Why: Previously, the function waited for Google Places to return before even initiating the Eventbrite request. Since these two calls are independent and don't share database state, they can be fired concurrently.
📊 Impact: Reduces the total latency of the `search_events` function by roughly 50% (from the sum of both API response times to simply the maximum of the two).
🔬 Measurement: Can be verified by timing the `search_events` endpoint before and after this change, noting the latency reduction on a live server. Evaluated the syntactic correctness via `py_compile` since local dependencies have conflicts preventing pytest execution.

---
*PR created automatically by Jules for task [970965880881148533](https://jules.google.com/task/970965880881148533) started by @Ralein*