### PR TITLE
⚡ Bolt: Parallelize external API calls in events search

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2024-10-27 - Parallelize independent external API requests
+**Learning:** Sequential HTTP calls can significantly degrade overall response times, especially when aggregating data from multiple external sources (like Google Places and Eventbrite).
+**Action:** Always identify independent, I/O-bound network calls within the same request lifecycle and parallelize them using `asyncio.gather()` to minimize total latency without impacting functional behavior.

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -4,6 +4,7 @@ Real events only — no mock data. Combines Google Places Nearby Search
 with Eventbrite event listings, merges and deduplicates results.
 """
 
+import asyncio
 import hashlib
 import httpx
 import time
@@ -330,10 +331,13 @@ async def search_events(
     if cached is not None:
         return cached
 
-    # Fire both API calls
+    # Fire both API calls concurrently to reduce latency
+    # ⚡ Bolt: Parallelizing independent external API requests improves overall response time.
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 


### PR DESCRIPTION
💡 **What:** 
Parallelized the `_search_google_places` and `_search_eventbrite` API calls in `apps/backend/app/services/events_service.py` using `asyncio.gather()`.

🎯 **Why:** 
Previously, the backend waited for the Google Places API response before initiating the Eventbrite API request. Since these two data sources are independent, fetching them sequentially unnecessarily inflates the total response time. Parallelizing them reduces the latency bottleneck to the duration of the slowest single request rather than the sum of both.

📊 **Impact:** 
Expect a significant reduction in overall execution time for `search_events`, cutting network latency down by nearly half (depending on the respective latencies of the external APIs). 

🔬 **Measurement:** 
I verified this improvement by writing a mock test with artificial delays simulating network latency. The mock test successfully confirmed that the total execution time dropped from the sum of delays to the maximum single delay.

---
*PR created automatically by Jules for task [780852173664747673](https://jules.google.com/task/780852173664747673) started by @Ralein*