### PR TITLE
⚡ Bolt: Parallelize independent external HTTP requests for event search

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-30 - [Parallelizing External HTTP API Requests]
+**Learning:** Sequential execution of independent external HTTP requests (like Google Places and Eventbrite API calls) leads to additive latency, creating a significant performance bottleneck in downstream handlers.
+**Action:** Always use `asyncio.gather` for independent network-bound API calls to parallelize them and bound the total latency by the slowest single request, instead of the sum of all requests.

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -4,6 +4,7 @@ Real events only — no mock data. Combines Google Places Nearby Search
 with Eventbrite event listings, merges and deduplicates results.
 """
 
+import asyncio
 import hashlib
 import httpx
 import time
@@ -330,10 +331,12 @@ async def search_events(
     if cached is not None:
         return cached
 
-    # Fire both API calls
+    # Fire both API calls concurrently
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 


### PR DESCRIPTION
💡 **What:** 
Parallelized the `_search_google_places` and `_search_eventbrite` external API calls using `asyncio.gather` in `apps/backend/app/services/events_service.py`. Added an entry to `.jules/bolt.md` reflecting on this learning.

🎯 **Why:** 
Previously, these two independent API calls were awaited sequentially. This meant the total time the user had to wait for results was the sum of the latencies of both requests. Since they are independent external network calls, executing them sequentially created an artificial performance bottleneck.

📊 **Impact:** 
Reduces the response time of the `/events` discovery endpoint. The new total latency is bounded by the slower of the two requests, rather than the sum of both. This could cut overall latency by nearly 50% in the best-case scenario (if both APIs take roughly the same amount of time).

🔬 **Measurement:** 
Run a quick ad-hoc timer script against the `search_events` function before and after this change. The total execution time will be noticeably faster when `asyncio.gather` is used.

---
*PR created automatically by Jules for task [570275359602108808](https://jules.google.com/task/570275359602108808) started by @Ralein*