### PR TITLE
⚡ Bolt: [performance improvement] Parallelize Google Places and Eventbrite event search

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2024-05-02 - Parallelize Independent External API Calls
+**Learning:** External API requests made via `httpx.AsyncClient` do not share the concurrency restrictions of database queries executed via SQLAlchemy's `AsyncSession`. While `AsyncSession` calls must be serialized (or batched using scalar subqueries), independent HTTP requests are safe to parallelize.
+**Action:** Use `asyncio.gather` for independent external HTTP requests (e.g., retrieving data from different sources like Google Places and Eventbrite) to reduce total request latency from the sum of the times to the max of the times.

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -4,6 +4,7 @@ Real events only — no mock data. Combines Google Places Nearby Search
 with Eventbrite event listings, merges and deduplicates results.
 """
 
+import asyncio
 import hashlib
 import httpx
 import time
@@ -332,8 +333,16 @@ async def search_events(
 
     # Fire both API calls
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+
+    # ⚡ Bolt Optimization:
+    # Run independent external HTTP requests concurrently using asyncio.gather.
+    # Unlike SQLAlchemy's AsyncSession which has concurrency restrictions,
+    # external requests via httpx.AsyncClient are independent and safe to parallelize.
+    # This reduces total latency by bounded execution to the slowest request rather than the sum.
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 


### PR DESCRIPTION
💡 **What:** Modified `search_events` in `apps/backend/app/services/events_service.py` to use `asyncio.gather`, executing `_search_google_places` and `_search_eventbrite` concurrently instead of sequentially.
🎯 **Why:** External API calls via `httpx.AsyncClient` are independent and I/O bound. Waiting for Google Places to complete before initiating the Eventbrite request arbitrarily doubles latency. Since these calls do not share SQLAlchemy `AsyncSession` restrictions, they can and should be parallelized to decrease the response time of the endpoint.
📊 **Impact:** Reduces total API latency from `Time(Google) + Time(Eventbrite)` to `Max(Time(Google), Time(Eventbrite))`. For example, if both take 1s, the total time drops from 2s to ~1s.
🔬 **Measurement:** Verified via a custom isolated mock script (`test_events_perf.py`) utilizing `pytest` which successfully asserted execution time dropping from the sum of mock delays (2s) to the max (1s). The file was deleted post-verification to ensure code cleanliness.

---
*PR created automatically by Jules for task [10060259971529751363](https://jules.google.com/task/10060259971529751363) started by @Ralein*