### PR TITLE
⚡ Bolt: Parallelize external API calls to Google Places and Eventbrite

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-28 - Parallelizing Independent Async Functions
+**Learning:** Sequential await statements for independent external HTTP APIs are a significant source of latency (N+1 bottleneck). SQLAlchemy AsyncSession does not support concurrency with `asyncio.gather`, but external HTTP requests via `httpx` and `AsyncClient` within service modules like `events_service.py` do support full concurrency.
+**Action:** When making multiple independent network calls in FastAPI services, always use `asyncio.gather` instead of sequential `await`s to effectively halve response times.

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -4,6 +4,7 @@ Real events only — no mock data. Combines Google Places Nearby Search
 with Eventbrite event listings, merges and deduplicates results.
 """
 
+import asyncio
 import hashlib
 import httpx
 import time
@@ -330,10 +331,15 @@ async def search_events(
     if cached is not None:
         return cached
 
-    # Fire both API calls
+    # Fire both API calls concurrently to reduce IO bottleneck
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+
+    # ⚡ Bolt: Execute both external HTTP requests concurrently via asyncio.gather
+    # instead of sequentially to halve latency.
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 


### PR DESCRIPTION
💡 What: Replaced sequential `await`s with `asyncio.gather` for independent external API calls (`_search_google_places` and `_search_eventbrite`) in `apps/backend/app/services/events_service.py`.

🎯 Why: Sequential external API requests act as a significant bottleneck, causing the endpoint latency to be the sum of both request durations. By parallelizing them, latency is dictated by the slowest request, effectively cutting it down by up to ~50%.

📊 Impact: Expected to halve the response time of the `search_events` function when handling a cache miss.

🔬 Measurement: Response latency can be measured using profiling tools or logging times before and after execution of `search_events`.

---
*PR created automatically by Jules for task [4852634480505614723](https://jules.google.com/task/4852634480505614723) started by @Ralein*