### PR TITLE
⚡ Bolt: Optimize events search by parallelizing external API calls

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-04 - [events_service] Parallelize independent HTTP requests
+**Learning:** External API requests in FastAPI handlers were being awaited sequentially. While SQLAlchemy `AsyncSession` cannot execute concurrently, standard independent `httpx` API calls have no such restriction and should always be run via `asyncio.gather` to minimize latency. Also, caching results combined from multiple APIs required including all search parameters (like `radius`) to prevent silent collisions when search areas differ.
+**Action:** When making multiple external API calls, check if they depend on each other. If not, use `asyncio.gather` to execute them in parallel and ensure all parameters modifying search outcomes are included in any caching logic.

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -4,6 +4,7 @@ Real events only — no mock data. Combines Google Places Nearby Search
 with Eventbrite event listings, merges and deduplicates results.
 """
 
+import asyncio
 import hashlib
 import httpx
 import time
@@ -50,9 +51,9 @@ _cache: dict[str, tuple[float, list[dict]]] = {}
 CACHE_TTL = 300  # 5 minutes
 
 
-def _cache_key(lat: float, lon: float, keyword: str | None) -> str:
-    """Generate a cache key from location + keyword."""
-    raw = f"{round(lat, 3)}:{round(lon, 3)}:{keyword or ''}"
+def _cache_key(lat: float, lon: float, radius: int, keyword: str | None) -> str:
+    """Generate a cache key from location, radius, and keyword."""
+    raw = f"{round(lat, 3)}:{round(lon, 3)}:{radius}:{keyword or ''}"
     return hashlib.md5(raw.encode()).hexdigest()
 
 
@@ -325,15 +326,20 @@ async def search_events(
 
     Returns merged, deduplicated results. Uses in-memory TTL cache.
     """
-    key = _cache_key(lat, lon, keyword)
+    key = _cache_key(lat, lon, radius, keyword)
     cached = _get_cached(key)
     if cached is not None:
         return cached
 
-    # Fire both API calls
+    # Fire both API calls concurrently
+    # Performance Optimization: asyncio.gather runs both independent external API calls in parallel
+    # This reduces total latency from O(Google + Eventbrite) to O(max(Google, Eventbrite))
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 


### PR DESCRIPTION
💡 **What**: Refactored the `search_events` method in `events_service.py` to use `asyncio.gather` for executing Google Places and Eventbrite API calls concurrently instead of sequentially. Also updated the `_cache_key` to include the `radius` parameter.
🎯 **Why**: External HTTP requests via `httpx` in standard async setups have no constraints that require sequential execution. Running independent API calls sequentially introduces unnecessary latency. By awaiting them in parallel, total latency is reduced to the maximum of the two responses rather than their sum. Including `radius` in the cache key fixes a bug where caches collide for searches at identical coordinates but varying sizes.
📊 **Impact**: This improves the responsiveness of the `search_events` endpoint and enhances user experience, especially when downstream API latencies fluctuate.
🔬 **Measurement**: Inspect network latency tracing on endpoint calls or log the start and end execution times of `search_events`; elapsed time should now closely mirror the slowest single API query.

*Note: Basic syntax was validated using `py_compile`, but full tests could not run locally due to conflicting environment dependencies between `langchain` and `kokoro-onnx` on `numpy`.*

---
*PR created automatically by Jules for task [6884404865327049416](https://jules.google.com/task/6884404865327049416) started by @Ralein*