### PR TITLE
⚡ Bolt: Parallelize external event API fetches

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-05 - Event Search Latency Optimization
+**Learning:** Sequential await calls for independent external APIs (`Google Places`, `Eventbrite`) create a bottleneck equal to the sum of their latencies.
+**Action:** Use `asyncio.gather()` to fetch data from independent data sources concurrently, reducing the total network request latency from `sum(latencies)` to `max(latencies)`.

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -4,6 +4,7 @@ Real events only — no mock data. Combines Google Places Nearby Search
 with Eventbrite event listings, merges and deduplicates results.
 """
 
+import asyncio
 import hashlib
 import httpx
 import time
@@ -330,10 +331,12 @@ async def search_events(
     if cached is not None:
         return cached
 
-    # Fire both API calls
+    # Fire both API calls concurrently
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 


### PR DESCRIPTION
💡 What: Refactored `search_events` in `events_service.py` to use `asyncio.gather()`, running Google Places and Eventbrite API calls concurrently instead of sequentially.
🎯 Why: Independent external API calls were blocking each other. The sequential execution created a latency bottleneck equal to `time(Google) + time(Eventbrite)`.
📊 Impact: Reduces total request latency from the sum of both latencies to the maximum of the two (`max(time(Google), time(Eventbrite))`). This should halve the latency of the event discovery endpoint.
🔬 Measurement: Verify by executing the events endpoint or timing `search_events` execution. Time should be dictated by the slower API rather than both.

---
*PR created automatically by Jules for task [12583656998593538846](https://jules.google.com/task/12583656998593538846) started by @Ralein*