### PR TITLE
⚡ Bolt: Parallelize external API calls in events_service

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-05-06 - [Parallelizing independent API calls]
+**Learning:** Utilizing `asyncio.gather` allows for parallel execution of independent external HTTP requests within an asynchronous service layer context, effectively cutting overall wait time significantly compared to sequentially awaiting them. This holds true as long as those calls do not share restricted resources such as a single SQLAlchemy `AsyncSession`.
+**Action:** Consistently search for sequential network I/O operations and employ `asyncio.gather` (or similar mechanisms) where safe to parallelize API interactions.

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -4,6 +4,7 @@ Real events only — no mock data. Combines Google Places Nearby Search
 with Eventbrite event listings, merges and deduplicates results.
 """
 
+import asyncio
 import hashlib
 import httpx
 import time
@@ -330,10 +331,16 @@ async def search_events(
     if cached is not None:
         return cached
 
-    # Fire both API calls
+    # Fire both API calls concurrently
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+
+    # ⚡ Bolt: Fetching events from Google Places and Eventbrite concurrently
+    # This reduces overall latency by executing both independent HTTP requests in parallel
+    # instead of sequentially, limited only by the slower of the two calls.
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 


### PR DESCRIPTION
💡 What: Updated `search_events` in `apps/backend/app/services/events_service.py` to fetch events from Google Places and Eventbrite concurrently using `asyncio.gather()`.
🎯 Why: Previously, these independent API calls were executed sequentially, causing the overall latency to be the sum of both network operations.
📊 Impact: Reduces the latency of the `search_events` function by approximately the time it takes the faster of the two requests to return.
🔬 Measurement: Verify by executing an event search and measuring request round-trip times; the operation should now be bounded by the slower of the two endpoints.

---
*PR created automatically by Jules for task [9346677573006742175](https://jules.google.com/task/9346677573006742175) started by @Ralein*