### PR TITLE
⚡ Bolt: Parallelize independent API calls to reduce events search latency

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Parallelizing Independent External API Calls
+**Learning:** External API calls in asynchronous Python applications (using libraries like `httpx`) are purely I/O bound. If they do not depend on each other and do not share constraints like SQLAlchemy's non-thread-safe `AsyncSession`, they should be executed concurrently. Sequential execution artificially bloats the overall latency.
+**Action:** When consuming multiple external data sources (like Google Places and Eventbrite), always combine them using `asyncio.gather()` rather than sequential `await`s to reduce the total response time to `max(T1, T2)` instead of `T1 + T2`.

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -4,6 +4,7 @@ Real events only — no mock data. Combines Google Places Nearby Search
 with Eventbrite event listings, merges and deduplicates results.
 """
 
+import asyncio
 import hashlib
 import httpx
 import time
@@ -332,8 +333,12 @@ async def search_events(
 
     # Fire both API calls
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+
+    # ⚡ Bolt Optimization: Run independent external API calls concurrently to reduce total latency.
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 


### PR DESCRIPTION
**💡 What:**
Refactored the `search_events` function in `apps/backend/app/services/events_service.py` to execute the external API calls to Google Places and Eventbrite concurrently using `asyncio.gather()`.

**🎯 Why:**
Previously, these two I/O-bound requests were `await`ed sequentially. Because they do not depend on each other and are just standard `httpx` calls (meaning they do not suffer from the `AsyncSession` lock limitations seen with DB queries), running them sequentially artificially inflated the latency. 

**📊 Impact:**
Total response time for fetching events will be reduced from `T(Google) + T(Eventbrite)` to roughly `max(T(Google), T(Eventbrite))`. For example, if both APIs take ~1 second to respond, the endpoint will now return in ~1 second instead of ~2 seconds.

**🔬 Measurement:**
Since full tests cannot currently run due to environment dependency conflicts, the syntax integrity has been verified via `py_compile`. In production, this can be measured by tracing the total execution time of the `search_events` endpoint before and after this deployment, expecting an approximately 30-50% reduction in endpoint latency.

Also added a journal entry to `.jules/bolt.md` detailing the learning about parallelizing independent API requests vs. thread-unsafe database sessions.

---
*PR created automatically by Jules for task [8527475067680319744](https://jules.google.com/task/8527475067680319744) started by @Ralein*