### PR TITLE
⚡ Bolt: Parallelize external API calls in events search

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-08 - Parallelize Independent External API Calls
+**Learning:** External API requests (e.g., via httpx.AsyncClient) made sequentially can accumulate network latency. Unlike database calls using SQLAlchemy AsyncSession which are not thread-safe, external HTTP requests have no concurrency restrictions.
+**Action:** Use `asyncio.gather` to execute independent external API calls concurrently to reduce overall wait time and improve service performance.

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -4,6 +4,7 @@ Real events only — no mock data. Combines Google Places Nearby Search
 with Eventbrite event listings, merges and deduplicates results.
 """
 
+import asyncio
 import hashlib
 import httpx
 import time
@@ -50,9 +51,9 @@ _cache: dict[str, tuple[float, list[dict]]] = {}
 CACHE_TTL = 300  # 5 minutes
 
 
-def _cache_key(lat: float, lon: float, keyword: str | None) -> str:
-    """Generate a cache key from location + keyword."""
-    raw = f"{round(lat, 3)}:{round(lon, 3)}:{keyword or ''}"
+def _cache_key(lat: float, lon: float, radius: int, keyword: str | None) -> str:
+    """Generate a cache key from location, radius + keyword."""
+    raw = f"{round(lat, 3)}:{round(lon, 3)}:{radius}:{keyword or ''}"
     return hashlib.md5(raw.encode()).hexdigest()
 
 
@@ -325,15 +326,17 @@ async def search_events(
 
     Returns merged, deduplicated results. Uses in-memory TTL cache.
     """
-    key = _cache_key(lat, lon, keyword)
+    key = _cache_key(lat, lon, radius, keyword)
     cached = _get_cached(key)
     if cached is not None:
         return cached
 
-    # Fire both API calls
+    # Fire both API calls concurrently
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 


### PR DESCRIPTION
💡 **What:**
- Wrapped the sequential calls to `_search_google_places` and `_search_eventbrite` within `search_events` using `asyncio.gather` for concurrent execution.
- Added `radius` to the cache key generation (`_cache_key`) to prevent incorrect cache hits when different queries share the same coordinates and keyword but have different radiuses.

🎯 **Why:**
- Sequential external HTTP calls accumulate network latency (e.g., if Google takes 300ms and Eventbrite takes 400ms, the total time is 700ms). Concurrent execution reduces the total wait time to the duration of the slowest request (400ms).
- Fixing the cache key prevents users from receiving cached events that are outside their requested radius.

📊 **Impact:**
- Significantly reduces the latency of the `/events` endpoint by overlapping network I/O operations. Expected improvement is roughly ~30-50% depending on individual API response times.

🔬 **Measurement:**
- Verified the parallel execution logic through code review.
- The latency improvement can be measured by comparing the `/events` endpoint response time before and after the change using standard profiling tools.

---
*PR created automatically by Jules for task [351916481591013989](https://jules.google.com/task/351916481591013989) started by @Ralein*