### PR TITLE
⚡ Bolt: Use asyncio.gather for parallel event API requests

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-13 - Use asyncio.gather for parallel external API requests
+**Learning:** Sequential execution of independent external HTTP requests (like fetching from Google Places and Eventbrite) creates an N+1 API call bottleneck. However, unlike SQLAlchemy AsyncSession which does not support concurrent queries, independent HTTP requests via httpx.AsyncClient can be safely parallelized using `asyncio.gather` to reduce total latency to the slowest request.
+**Action:** Whenever fetching data from multiple independent external sources, use `asyncio.gather` instead of sequential `await`s to minimize network wait times.

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -4,6 +4,7 @@ Real events only — no mock data. Combines Google Places Nearby Search
 with Eventbrite event listings, merges and deduplicates results.
 """
 
+import asyncio
 import hashlib
 import httpx
 import time
@@ -332,8 +333,13 @@ async def search_events(
 
     # Fire both API calls
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+
+    # ⚡ Bolt Optimization: Use asyncio.gather to fetch from both sources concurrently
+    # This prevents the N+1 waiting problem and reduces total wait time to the slowest request.
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 


### PR DESCRIPTION
💡 What: Refactored the `search_events` function in `events_service.py` to use `asyncio.gather` for fetching data from Google Places and Eventbrite concurrently.
🎯 Why: Previously, the function awaited the Google Places HTTP request, and only after it completed did it initiate and await the Eventbrite HTTP request. This sequential execution caused an N+1 waiting problem, artificially increasing response times by summing the latencies of both requests.
📊 Impact: Total wait time is reduced from `time(req1) + time(req2)` to roughly `max(time(req1), time(req2))`, significantly decreasing the API's overall latency.
🔬 Measurement: Verify by executing an API request to the relevant events endpoint and comparing network trace response times before and after this change.

---
*PR created automatically by Jules for task [16035636009264078939](https://jules.google.com/task/16035636009264078939) started by @Ralein*