### PR TITLE
⚡ Bolt: [parallelize external HTTP requests in events_service]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-25 - Parallelize Independent External HTTP Requests
+**Learning:** While SQLAlchemy AsyncSession restricts concurrent execution for database calls, independent external HTTP requests (e.g., via httpx.AsyncClient) do not share this limitation. The `events_service.py` was fetching Google Places and Eventbrite results sequentially, causing unnecessary latency by waiting for one API call to finish before starting the other.
+**Action:** Always use `asyncio.gather` to execute independent external API calls concurrently to minimize latency. Ensure no shared mutable state or database session concurrency limitations apply to the specific calls being parallelized.

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -4,6 +4,7 @@ Real events only — no mock data. Combines Google Places Nearby Search
 with Eventbrite event listings, merges and deduplicates results.
 """
 
+import asyncio
 import hashlib
 import httpx
 import time
@@ -330,10 +331,15 @@ async def search_events(
     if cached is not None:
         return cached
 
-    # Fire both API calls
+    # ⚡ Bolt Optimization: Fire both API calls concurrently
+    # Both APIs are independent external HTTP requests. Using asyncio.gather
+    # reduces the total latency to max(Google, Eventbrite) instead of Google + Eventbrite.
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 


### PR DESCRIPTION
💡 What: Wrapped independent Google Places and Eventbrite API calls in `asyncio.gather` within `search_events`.
🎯 Why: Previously, these independent external requests were running sequentially, blocking each other and causing unnecessary end-to-end latency.
📊 Impact: Reduces total latency of `search_events` from `latency(Google) + latency(Eventbrite)` to roughly `max(latency(Google), latency(Eventbrite))`.
🔬 Measurement: Verify by measuring the execution time of `search_events` endpoint and observing the network waterfall; the API calls to `maps.googleapis.com` and `eventbriteapi.com` should now occur concurrently.

---
*PR created automatically by Jules for task [15317240493525826316](https://jules.google.com/task/15317240493525826316) started by @Ralein*