### PR TITLE
⚡ Bolt: [performance improvement] concurrent event search

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-17 - Parallelizing Independent Third-Party API Calls
+**Learning:** In backend services that aggregate data from multiple third-party APIs (e.g., Google Places and Eventbrite), fetching them sequentially causes the total latency to be the sum of both network requests. Unlike database calls with SQLAlchemy `AsyncSession` which cannot execute concurrently, external HTTP requests (e.g., via `httpx.AsyncClient`) are perfectly safe to parallelize.
+**Action:** Use `asyncio.gather` for independent HTTP calls to third-party APIs to optimize I/O performance and bound the latency to the slowest single request, instead of the sum of all requests.

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -4,6 +4,7 @@ Real events only — no mock data. Combines Google Places Nearby Search
 with Eventbrite event listings, merges and deduplicates results.
 """
 
+import asyncio
 import hashlib
 import httpx
 import time
@@ -330,10 +331,12 @@ async def search_events(
     if cached is not None:
         return cached
 
-    # Fire both API calls
+    # Fire both API calls concurrently to reduce total latency
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 

--- a/apps/backend/test_events_perf.py
+++ b/apps/backend/test_events_perf.py
@@ -1,0 +1,26 @@
+import asyncio
+import time
+from unittest.mock import patch
+from app.services.events_service import search_events, _cache
+
+async def mock_search_google(*args, **kwargs):
+    await asyncio.sleep(1) # simulate 1s network latency
+    return [{"event_id": "gp_1", "name": "Google Yoga", "category": "yoga"}]
+
+async def mock_search_eventbrite(*args, **kwargs):
+    await asyncio.sleep(1) # simulate 1s network latency
+    return [{"event_id": "eb_1", "name": "Eventbrite Yoga", "category": "yoga"}]
+
+async def main():
+    _cache.clear()
+    start_time = time.time()
+
+    with patch("app.services.events_service._search_google_places", mock_search_google), \
+         patch("app.services.events_service._search_eventbrite", mock_search_eventbrite):
+        await search_events(lat=40.7128, lon=-74.0060, radius=25, keyword="yoga")
+
+    duration = time.time() - start_time
+    print(f"Original execution time: {duration:.2f} seconds")
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
💡 What: Used `asyncio.gather` to execute external HTTP requests concurrently in `search_events`.
🎯 Why: Sequential API calls sum up the latencies of both networks. Running them concurrently bounds the delay to the slowest single request.
📊 Impact: Halves the search endpoint latency when both API calls have roughly similar network delay (e.g. going from ~2.0s to ~1.0s).
🔬 Measurement: Verified using an isolated test script (`test_events_perf.py`) injecting 1s latencies to both mock requests. Execution time halved from 2.0s to 1.0s.

---
*PR created automatically by Jules for task [2962946318288834478](https://jules.google.com/task/2962946318288834478) started by @Ralein*