### PR TITLE
⚡ Bolt: Parallelize independent external API searches to reduce overall latency

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-05-18 - [Parallelize External API Calls in Event Service]
+**Learning:** Sequential execution of independent external API calls (e.g., Google Places and Eventbrite) creates a cumulative performance bottleneck, where the total waiting time is the sum of both response times.
+**Action:** Use `asyncio.gather` to parallelize independent network requests within async functions to reduce the total latency to the maximum of the individual request times, rather than their sum.

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -4,6 +4,7 @@ Real events only — no mock data. Combines Google Places Nearby Search
 with Eventbrite event listings, merges and deduplicates results.
 """
 
+import asyncio
 import hashlib
 import httpx
 import time
@@ -332,8 +333,12 @@ async def search_events(
 
     # Fire both API calls
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+
+    # ⚡ Bolt: Parallelize independent external API calls to reduce total search latency
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 


### PR DESCRIPTION
**💡 What**
Replaced sequential `await` calls in `search_events` with `asyncio.gather` for parallelizing independent external network requests to Google Places and Eventbrite APIs. 

**🎯 Why**
Previously, the total API wait time was the sum of both the Google Places and Eventbrite response times. Since these external requests are independent, executing them sequentially created an unnecessary cumulative performance bottleneck. 

**📊 Impact**
Reduces the latency of the `search_events` function. Total request latency is now bounded by the maximum response time of the two API calls, rather than their sum.

**🔬 Measurement**
Run performance benchmarking against the `search_events` function. Observe total execution time, which should now closely map to the slowest of the two external requests rather than both combined. Review journal in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [17600884500415060903](https://jules.google.com/task/17600884500415060903) started by @Ralein*