### PR TITLE
⚡ Bolt: [performance improvement] Parallelize event API calls

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-20 - Concurrent External API Calls vs Database Queries
+**Learning:** Sequential awaits for independent external APIs (like Google Places and Eventbrite) create an unnecessary bottleneck, summing their latencies.
+**Action:** Always use `asyncio.gather` for independent external API calls to reduce latency by parallelizing them, as they do not share the concurrency restrictions of SQLAlchemy `AsyncSession`.

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -4,6 +4,7 @@ Real events only — no mock data. Combines Google Places Nearby Search
 with Eventbrite event listings, merges and deduplicates results.
 """
 
+import asyncio
 import hashlib
 import httpx
 import time
@@ -332,8 +333,15 @@ async def search_events(
 
     # Fire both API calls
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+
+    # ⚡ Bolt Optimization: Parallelize independent external API calls
+    # 🎯 Why: Previously, these calls were awaited sequentially (sum of latencies).
+    # 📊 Impact: Reduces total latency to max(Google_latency, Eventbrite_latency) instead of Google_latency + Eventbrite_latency (~50% faster if latencies are similar).
+    # 🔬 Measurement: Observe total duration of `search_events` before and after this change.
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 


### PR DESCRIPTION
💡 What: Refactored the `search_events` function in `apps/backend/app/services/events_service.py` to use `asyncio.gather()` for the Google Places and Eventbrite external API calls.
🎯 Why: Previously, these two independent API calls were executed sequentially, meaning the user had to wait for Google Places to finish *before* the Eventbrite call even started. This created an unnecessary I/O bottleneck.
📊 Impact: Expected to reduce total latency for fetching events by nearly 50% (assuming both APIs take a roughly similar amount of time), changing total latency from `Google_Time + Eventbrite_Time` to `max(Google_Time, Eventbrite_Time)`.
🔬 Measurement: Can be observed and measured by tracking the execution duration of the `search_events` API endpoint under load, or by observing total TTFB on the client.

---
*PR created automatically by Jules for task [8348639170659256766](https://jules.google.com/task/8348639170659256766) started by @Ralein*