### PR TITLE
⚡ Bolt: [performance improvement] Parallelize API calls in search_events

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-05-21 - Parallelize Independent API Calls with asyncio.gather
+**Learning:** Sequential execution of independent asynchronous operations (like calling Google Places API and Eventbrite API one after another) introduces a significant performance bottleneck by accumulating network latencies.
+**Action:** Always use `asyncio.gather` to run independent network or I/O-bound coroutines concurrently. This reduces the total execution time to roughly the duration of the slowest single operation rather than the sum of all operations.

--- a/apps/backend/app/services/events_service.py
+++ b/apps/backend/app/services/events_service.py
@@ -4,6 +4,7 @@ Real events only — no mock data. Combines Google Places Nearby Search
 with Eventbrite event listings, merges and deduplicates results.
 """
 
+import asyncio
 import hashlib
 import httpx
 import time
@@ -330,10 +331,14 @@ async def search_events(
     if cached is not None:
         return cached
 
-    # Fire both API calls
+    # Fire both API calls concurrently using asyncio.gather
+    # This prevents the sequential bottleneck of waiting for Google before querying Eventbrite
     radius_meters = int(radius * 1609.34)  # miles → meters for Google
-    google_results = await _search_google_places(lat, lon, radius_meters, keyword)
-    eb_results = await _search_eventbrite(lat, lon, radius, keyword)
+
+    google_results, eb_results = await asyncio.gather(
+        _search_google_places(lat, lon, radius_meters, keyword),
+        _search_eventbrite(lat, lon, radius, keyword)
+    )
 
     merged = _merge_events(google_results, eb_results)
 


### PR DESCRIPTION
💡 What: Used `asyncio.gather()` to execute the `_search_google_places` and `_search_eventbrite` functions concurrently inside `search_events`.
🎯 Why: The original implementation `await`ed these two independent external network requests sequentially, introducing a bottleneck where the total execution time was essentially the sum of the latencies. By running them concurrently, we remove the sequential bottleneck and reduce the latency accumulation.
📊 Impact: Expected to reduce the overall response time of the `search_events` endpoint to roughly the latency of the slowest individual request rather than the combined duration of both.
🔬 Measurement: Use timing around the endpoint or view network traces to observe the time difference when querying both Eventbrite and Google Places APIs compared to the previous sequential implementation.

---
*PR created automatically by Jules for task [12584001863579745639](https://jules.google.com/task/12584001863579745639) started by @Ralein*